### PR TITLE
Create FrenlyFacesDiscordVerificationBot.md

### DIFF
--- a/FrenlyFacesDiscordVerificationBot.md
+++ b/FrenlyFacesDiscordVerificationBot.md
@@ -9,6 +9,10 @@ This is a combination frontend / backend, released under MIT license, that allow
 - [React Frontend](https://github.com/frenlyfaces/verify-frontend)
 - [Express Backend](https://github.com/frenlyfaces/verify-backend)
 
+## video demo
+
+https://user-images.githubusercontent.com/35851667/219746509-59f48db2-e515-48c7-aea3-cc38a1487c2b.mp4
+
 ## live demos
 
 - [Frenly Faces](https://frenlyfaces.xyz/verify)
@@ -17,3 +21,6 @@ This is a combination frontend / backend, released under MIT license, that allow
 ## license
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+

--- a/FrenlyFacesDiscordVerificationBot.md
+++ b/FrenlyFacesDiscordVerificationBot.md
@@ -1,0 +1,19 @@
+# Frenly Faces Discord Verification Bot
+
+This is a combination frontend / backend, released under MIT license, that allows projects to NFT gate a discord role and configure secret channels and other things for thier holders in Discord chat. This was created for the hackatthon and is already in production use in both my own community, Frenly Faces, as well as the Shnoises discord server which I have assisted with setting that up for them. Cheers!
+
+-Sayuki0x ([@Sayuki0x](https://twitter.com/Sayuki0x) on Twitter)
+
+## repositories
+
+- [React Frontend](https://github.com/frenlyfaces/verify-frontend)
+- [Express Backend](https://github.com/frenlyfaces/verify-backend)
+
+## live demos
+
+- [Frenly Faces](https://frenlyfaces.xyz/verify)
+- [Shnoises](https://verify.shnoise.com)
+
+## license
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
# Frenly Faces Discord Verification Bot

This is a combination frontend / backend, released under MIT license, that allows projects to NFT gate a discord role and configure secret channels and other things for thier holders in Discord chat. This was created for the hackatthon and is already in production use in both my own community, Frenly Faces, as well as the Shnoises discord server which I have assisted with setting that up for them. Cheers!

-Sayuki0x ([@Sayuki0x](https://twitter.com/Sayuki0x) on Twitter)

## repositories

- [React Frontend](https://github.com/frenlyfaces/verify-frontend)
- [Express Backend](https://github.com/frenlyfaces/verify-backend)

## video demo

https://user-images.githubusercontent.com/35851667/219746509-59f48db2-e515-48c7-aea3-cc38a1487c2b.mp4

## live demos

- [Frenly Faces](https://frenlyfaces.xyz/verify)
- [Shnoises](https://verify.shnoise.com)

## license

THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.



