### PR TITLE
Defillama Aggregator

### DIFF
--- a/defillama-aggregator/README.md
+++ b/defillama-aggregator/README.md
@@ -1,0 +1,4 @@
+# DefiLlama Aggregator
+We deployed a dex aggregator for canto that aggregates prices across Canto Dex, ForteSwap and CantoSwap. Now you can trade on canto at https://swap.defillama.com/?chain=canto&from=0x0000000000000000000000000000000000000000
+
+Canto Dex doesnt have an official UI in an effort to be decentralized, which makes it even more important for alternatives such as our aggregator to exist. As far as we know, when deployed this was the first alternative UI for canto dex other than slingshot.


### PR DESCRIPTION
### DefiLlama Aggregator
We deployed a dex aggregator for canto that aggregates prices across Canto Dex, ForteSwap and CantoSwap. Now you can trade on canto at https://swap.defillama.com/?chain=canto&from=0x0000000000000000000000000000000000000000

Canto Dex doesnt have an official UI in an effort to be decentralized, which makes it even more important for alternatives such as our aggregator to exist. As far as we know, when deployed this was the first alternative UI for canto dex other than slingshot.